### PR TITLE
[DRAFT] Study `ERC20Votes`

### DIFF
--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -20,10 +20,11 @@ import {SafeCast} from "@openzeppelin/utils/math/SafeCast.sol";
 
 import {Multicall} from "@openzeppelin/utils/Multicall.sol";
 import {Ownable2Step} from "@openzeppelin/access/Ownable2Step.sol";
+import {ERC20Votes} from "@openzeppelin/token/ERC20/extensions/ERC20Votes.sol";
 import {IERC20Metadata, ERC20Permit} from "@openzeppelin/token/ERC20/extensions/ERC20Permit.sol";
 import {IERC20, IERC4626, ERC20, ERC4626, Math, SafeERC20} from "@openzeppelin/token/ERC20/extensions/ERC4626.sol";
 
-contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorpho {
+contract MetaMorpho is ERC4626, ERC20Permit, ERC20Votes, Ownable2Step, Multicall, IMetaMorpho {
     using Math for uint256;
     using UtilsLib for uint256;
     using SafeCast for uint256;
@@ -444,6 +445,20 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
         }
 
         assets += idle;
+    }
+
+    /* ERC20Votes (INTERNAL) */
+
+    function _mint(address account, uint256 amount) internal override(ERC20, ERC20Votes) {
+        ERC20Votes._mint(account, amount);
+    }
+
+    function _burn(address account, uint256 amount) internal override(ERC20, ERC20Votes) {
+        ERC20Votes._burn(account, amount);
+    }
+
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal override(ERC20, ERC20Votes) {
+        ERC20Votes._afterTokenTransfer(from, to, amount);
     }
 
     /* ERC4626 (INTERNAL) */


### PR DESCRIPTION
[`ERC20Votes` doc](https://docs.openzeppelin.com/contracts/4.x/api/token/erc20#ERC20Votes)


Contract size (without via ir and opti) before:
<img width="562" alt="Screenshot 2023-10-05 at 10 28 24" src="https://github.com/morpho-labs/morpho-blue-metamorpho/assets/44097430/d54f5c74-9231-4a0a-8321-29adb4425f7e">

After:
<img width="559" alt="Screenshot 2023-10-05 at 10 29 49" src="https://github.com/morpho-labs/morpho-blue-metamorpho/assets/44097430/78ef511e-a4f5-4f11-b1ef-0d25c0a478de">

+3KB
