### PR TITLE
feat: add natspec about empty supply queue

### DIFF
--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -269,6 +269,7 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
     /// @notice Sets `supplyQueue` to `newSupplyQueue`.
     /// @dev The supply queue can be a set containing duplicate markets, but it would only increase the cost of
     /// depositing to the vault.
+    /// @dev The supply queue can be empty to minimize gas costs on deposits.
     function setSupplyQueue(Id[] calldata newSupplyQueue) external onlyAllocator {
         uint256 length = newSupplyQueue.length;
 

--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -269,7 +269,8 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
     /// @notice Sets `supplyQueue` to `newSupplyQueue`.
     /// @dev The supply queue can be a set containing duplicate markets, but it would only increase the cost of
     /// depositing to the vault.
-    /// @dev The supply queue can be empty to minimize gas costs on deposits.
+    /// @dev The supply queue can be empty to minimize gas costs on deposits. In that case, the deposited assets stay
+    /// idle until the next reallocation (triggered by allocators).
     function setSupplyQueue(Id[] calldata newSupplyQueue) external onlyAllocator {
         uint256 length = newSupplyQueue.length;
 

--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -270,7 +270,7 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
     /// @dev The supply queue can be a set containing duplicate markets, but it would only increase the cost of
     /// depositing to the vault.
     /// @dev The supply queue can be empty to minimize gas costs on deposits. In that case, the deposited assets stay
-    /// idle until the next reallocation (triggered by allocators).
+    /// idle until it is reallocated on a market later by the allocators.
     function setSupplyQueue(Id[] calldata newSupplyQueue) external onlyAllocator {
         uint256 length = newSupplyQueue.length;
 


### PR DESCRIPTION
Fixes #214 

Should I add a line explaining that in this case, the deposited assets stay idle until the next reallocation (done by allocators) ?