### PR TITLE
Replace the withdraw rank with a boolean

### DIFF
--- a/src/interfaces/IMetaMorpho.sol
+++ b/src/interfaces/IMetaMorpho.sol
@@ -7,8 +7,8 @@ import {IERC4626} from "@openzeppelin/interfaces/IERC4626.sol";
 struct MarketConfig {
     /// @notice The maximum amount of assets that can be allocated to the market.
     uint192 cap;
-    /// @notice The rank of the market in the withdraw queue.
-    uint64 withdrawRank;
+    /// @notice Whether the market is in the withdraw queue.
+    bool inWithdrawQueue;
 }
 
 struct PendingUint192 {
@@ -50,7 +50,7 @@ interface IMetaMorpho is IERC4626 {
     function supplyQueueSize() external view returns (uint256);
     function withdrawQueue(uint256) external view returns (Id);
     function withdrawQueueSize() external view returns (uint256);
-    function config(Id) external view returns (uint192 cap, uint64 withdrawRank);
+    function config(Id) external view returns (uint192 cap, bool inWithdrawQueue);
 
     function idle() external view returns (uint256);
     function lastTotalAssets() external view returns (uint256);

--- a/test/forge/GuardianTest.sol
+++ b/test/forge/GuardianTest.sol
@@ -67,11 +67,11 @@ contract GuardianTest is IntegrationTest {
         vm.prank(GUARDIAN);
         vault.revokeCap(id);
 
-        (uint192 newCap, uint64 withdrawRank) = vault.config(id);
+        (uint192 newCap, bool inWithdrawQueue) = vault.config(id);
         (uint256 pendingCap, uint64 submittedAt) = vault.pendingCap(id);
 
         assertEq(newCap, 0, "newCap");
-        assertEq(withdrawRank, 0, "withdrawRank");
+        assertEq(inWithdrawQueue, false, "inWithdrawQueue");
         assertEq(pendingCap, 0, "pendingCap");
         assertEq(submittedAt, 0, "submittedAt");
     }

--- a/test/forge/TimelockTest.sol
+++ b/test/forge/TimelockTest.sol
@@ -341,11 +341,11 @@ contract TimelockTest is IntegrationTest {
         vm.prank(CURATOR);
         vault.submitCap(marketParams, cap);
 
-        (uint192 newCap, uint64 withdrawRank) = vault.config(id);
+        (uint192 newCap, bool inWithdrawQueue) = vault.config(id);
         (uint192 pendingCap, uint64 submittedAt) = vault.pendingCap(id);
 
         assertEq(newCap, cap, "newCap");
-        assertEq(withdrawRank, 1, "withdrawRank");
+        assertEq(inWithdrawQueue, true, "inWithdrawQueue");
         assertEq(pendingCap, 0, "pendingCap");
         assertEq(submittedAt, 0, "submittedAt");
     }
@@ -361,11 +361,11 @@ contract TimelockTest is IntegrationTest {
         vm.prank(CURATOR);
         vault.submitCap(marketParams, cap);
 
-        (uint192 newCap, uint64 withdrawRank) = vault.config(id);
+        (uint192 newCap, bool inWithdrawQueue) = vault.config(id);
         (uint192 pendingCap, uint64 submittedAt) = vault.pendingCap(id);
 
         assertEq(newCap, 0, "newCap");
-        assertEq(withdrawRank, 0, "withdrawRank");
+        assertEq(inWithdrawQueue, false, "inWithdrawQueue");
         assertEq(pendingCap, cap, "pendingCap");
         assertEq(submittedAt, block.timestamp, "submittedAt");
         assertEq(vault.supplyQueueSize(), 1, "supplyQueueSize");
@@ -387,11 +387,11 @@ contract TimelockTest is IntegrationTest {
         emit EventsLib.SetCap(id, cap);
         vault.acceptCap(id);
 
-        (uint192 newCap, uint64 withdrawRank) = vault.config(id);
+        (uint192 newCap, bool inWithdrawQueue) = vault.config(id);
         (uint192 pendingCapAfter, uint64 submittedAtAfter) = vault.pendingCap(id);
 
         assertEq(newCap, cap, "newCap");
-        assertEq(withdrawRank, 1, "withdrawRank");
+        assertEq(inWithdrawQueue, true, "inWithdrawQueue");
         assertEq(pendingCapAfter, 0, "pendingCapAfter");
         assertEq(submittedAtAfter, 0, "submittedAtAfter");
         assertEq(Id.unwrap(vault.supplyQueue(0)), Id.unwrap(id), "supplyQueue");

--- a/test/metamorpho_tests.tree
+++ b/test/metamorpho_tests.tree
@@ -173,7 +173,7 @@
                 │   └── revert with AlreadySet()
                 └── when newSupplyCap != supplyCap
                     ├── when newSupplyCap < supplyCap
-                    │   ├── when newSupplyCap > 0 and marketConfig.withdrawRank == 0
+                    │   ├── when newSupplyCap > 0 and !marketConfig.inWithdrawQueue
                     │   │   ├── it should push id to supplyQueue
                     │   │   ├── it should push id to withdrawQueue
                     │   │   └── if withdrawQueue.length > MAX_QUEUE_SIZE
@@ -196,7 +196,7 @@
             ├── when block.timestamp > pendingCap[id].submittedAt + timelock + TIMELOCK_EXPIRATION
             │   └── revert with TIMELOCK_EXPIRATION_EXCEEDED
             └── whenblock.timestamp <= pendingCap[id].submittedAt + timelock + TIMELOCK_EXPIRATION
-                ├── when supplyCap > 0 and marketConfig.withdrawRank == 0
+                ├── when supplyCap > 0 and !marketConfig.inWithdrawQueue
                 │   ├── it should push id to supplyQueue
                 │   ├── it should push id to withdrawQueue
                 │   ├── if supplyQueue.length > MAX_QUEUE_SIZE
@@ -240,7 +240,7 @@
             │   │   ├── it should compute the id of this market
             │   │   └── revert with MissingMarket(id)
             │   └── when all these markets have zero cap and zero vault's supply
-            │       └── it should delete the withdrawRank of these markets
+            │       └── it should set the inWithdrawQueue of these markets to false
             ├── it should set withdrawQueue to newWithdrawQueue
             └── it shoud emit SetWithdrawQueue(msg.sender, newWithdrawQueue)
 


### PR DESCRIPTION
Credits to Maxim from OZ for this finding.

The purpose is performance, wich should come mainly from the removal of the SSTORE in the withraw loop inside `reallocate`