### PR TITLE
refactor(reallocate): expect final allocation

### DIFF
--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -376,16 +376,17 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
 
                 totalWithdrawn += withdrawnAssets;
             } else {
-                uint256 supplied = allocation.assets.zeroFloorSub(supplyAssets);
-                if (supplied == 0) continue;
+                uint256 suppliedAssets = allocation.assets.zeroFloorSub(supplyAssets);
+                if (suppliedAssets == 0) continue;
 
                 uint256 supplyCap = config[id].cap;
                 if (supplyCap == 0) revert ErrorsLib.UnauthorizedMarket(id);
 
-                if (supplyAssets + supplied > supplyCap) revert ErrorsLib.SupplyCapExceeded(id);
+                if (supplyAssets + suppliedAssets > supplyCap) revert ErrorsLib.SupplyCapExceeded(id);
 
-                (uint256 suppliedAssets, uint256 suppliedShares) =
-                    MORPHO.supply(allocation.marketParams, supplied, 0, address(this), hex"");
+                // The market's loan asset is guaranteed to be the vault's asset because it has a non-zero supply cap.
+                (, uint256 suppliedShares) =
+                    MORPHO.supply(allocation.marketParams, suppliedAssets, 0, address(this), hex"");
 
                 emit EventsLib.ReallocateSupply(_msgSender(), id, suppliedAssets, suppliedShares);
 

--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -342,8 +342,15 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
     }
 
     /// @notice Reallocates the vault's liquidity so as to reach a given allocation of assets on each given market.
-    /// @dev The allocator can withdraw from any market, even if it's not in the withdraw queue, as long as the loan
+    /// @notice The allocator can withdraw from any market, even if it's not in the withdraw queue, as long as the loan
     /// token of the market is the same as the vault's asset.
+    /// @dev The behavior of the reallocation can be altered by state changes, including:
+    /// - Deposits on the vault that supplies to markets that are expected to be supplied to during reallocation.
+    /// - Withdrawals from the vault that withdraws from markets that are expected to be withdrawn from during
+    /// reallocation.
+    /// - Donations to the vault on markets that are expected to be supplied to during reallocation.
+    /// - Withdrawals from markets that are expected to be withdrawn from during reallocation.
+    /// @dev Any additional liquidity withdrawn during reallocation will be kept idle.
     function reallocate(MarketAllocation[] calldata allocations) external onlyAllocatorRole {
         uint256 totalSupplied;
         uint256 totalWithdrawn;

--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -345,7 +345,6 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
     /// `supplied`).
     /// @dev The allocator can withdraw from any market, even if it's not in the withdraw queue, as long as the loan
     /// token of the market is the same as the vault's asset.
-
     function reallocate(MarketAllocation[] calldata allocations) external onlyAllocatorRole {
         uint256 totalSupplied;
         uint256 totalWithdrawn;

--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -351,12 +351,11 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
             MarketAllocation memory allocation = allocations[i];
             Id id = allocation.marketParams.id();
 
-            MORPHO.accrueInterest(allocation.marketParams);
-
-            Market memory market = MORPHO.market(id);
+            (uint256 totalSupplyAssets, uint256 totalSupplyShares,,) =
+                MORPHO.expectedMarketBalances(allocation.marketParams);
 
             uint256 supplyShares = MORPHO.supplyShares(id, address(this));
-            uint256 supplyAssets = supplyShares.toAssetsDown(market.totalSupplyAssets, market.totalSupplyShares);
+            uint256 supplyAssets = supplyShares.toAssetsDown(totalSupplyAssets, totalSupplyShares);
             uint256 withdrawn = supplyAssets.zeroFloorSub(allocation.assets);
 
             if (withdrawn > 0) {

--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -344,11 +344,11 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
     /// `supplied`).
     /// @dev The allocator can withdraw from any market, even if it's not in the withdraw queue, as long as the loan
     /// token of the market is the same as the vault's asset.
-    function reallocate(MarketAllocation[] calldata totalAllocation) external onlyAllocatorRole {
+    function reallocate(MarketAllocation[] calldata allocations) external onlyAllocatorRole {
         uint256 totalSupplied;
         uint256 totalWithdrawn;
-        for (uint256 i; i < totalAllocation.length; ++i) {
-            MarketAllocation memory allocation = totalAllocation[i];
+        for (uint256 i; i < allocations.length; ++i) {
+            MarketAllocation memory allocation = allocations[i];
             Id id = allocation.marketParams.id();
 
             if (allocation.marketParams.loanToken != asset()) revert ErrorsLib.InconsistentAsset(id);

--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -652,7 +652,7 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
 
     /// @dev Returns the vault's balance the market defined by `marketParams`.
     function _supplyBalance(MarketParams memory marketParams) internal view returns (uint256) {
-        return MORPHO.expectedSupplyBalance(marketParams, address(this));
+        return MORPHO.expectedSupplyAssets(marketParams, address(this));
     }
 
     /// @dev Reverts if `newTimelock` is not within the bounds.

--- a/src/interfaces/IMetaMorpho.sol
+++ b/src/interfaces/IMetaMorpho.sol
@@ -81,7 +81,7 @@ interface IMetaMorpho is IERC4626 {
 
     function setSupplyQueue(Id[] calldata newSupplyQueue) external;
     function sortWithdrawQueue(uint256[] calldata indexes) external;
-    function reallocate(MarketAllocation[] calldata withdrawn, MarketAllocation[] calldata supplied) external;
+    function reallocate(MarketAllocation[] calldata totalAllocation) external;
 }
 
 interface IPending {

--- a/src/interfaces/IMetaMorpho.sol
+++ b/src/interfaces/IMetaMorpho.sol
@@ -81,7 +81,7 @@ interface IMetaMorpho is IERC4626 {
 
     function setSupplyQueue(Id[] calldata newSupplyQueue) external;
     function sortWithdrawQueue(uint256[] calldata indexes) external;
-    function reallocate(MarketAllocation[] calldata totalAllocation) external;
+    function reallocate(MarketAllocation[] calldata allocations) external;
 }
 
 interface IPending {

--- a/test/forge/ERC4626Test.sol
+++ b/test/forge/ERC4626Test.sol
@@ -34,7 +34,7 @@ contract ERC4626Test is IntegrationTest, IMorphoFlashLoanCallback {
 
         assertGt(deposited, 0, "deposited");
         assertEq(vault.balanceOf(ONBEHALF), shares, "balanceOf(ONBEHALF)");
-        assertEq(morpho.expectedSupplyBalance(allMarkets[0], address(vault)), assets, "expectedSupplyBalance(vault)");
+        assertEq(morpho.expectedSupplyAssets(allMarkets[0], address(vault)), assets, "expectedSupplyAssets(vault)");
     }
 
     function testDeposit(uint256 assets) public {
@@ -49,7 +49,7 @@ contract ERC4626Test is IntegrationTest, IMorphoFlashLoanCallback {
 
         assertGt(shares, 0, "shares");
         assertEq(vault.balanceOf(ONBEHALF), shares, "balanceOf(ONBEHALF)");
-        assertEq(morpho.expectedSupplyBalance(allMarkets[0], address(vault)), assets, "expectedSupplyBalance(vault)");
+        assertEq(morpho.expectedSupplyAssets(allMarkets[0], address(vault)), assets, "expectedSupplyAssets(vault)");
     }
 
     function testRedeem(uint256 deposited, uint256 redeemed) public {
@@ -138,7 +138,7 @@ contract ERC4626Test is IntegrationTest, IMorphoFlashLoanCallback {
         assertEq(shares, minted, "shares");
         assertEq(vault.balanceOf(ONBEHALF), 0, "balanceOf(ONBEHALF)");
         assertEq(loanToken.balanceOf(RECEIVER), assets, "loanToken.balanceOf(RECEIVER)");
-        assertEq(morpho.expectedSupplyBalance(allMarkets[0], address(vault)), 0, "expectedSupplyBalance(vault)");
+        assertEq(morpho.expectedSupplyAssets(allMarkets[0], address(vault)), 0, "expectedSupplyAssets(vault)");
     }
 
     function testRedeemAll(uint256 deposited) public {
@@ -157,7 +157,7 @@ contract ERC4626Test is IntegrationTest, IMorphoFlashLoanCallback {
         assertEq(assets, deposited, "assets");
         assertEq(vault.balanceOf(ONBEHALF), 0, "balanceOf(ONBEHALF)");
         assertEq(loanToken.balanceOf(RECEIVER), deposited, "loanToken.balanceOf(RECEIVER)");
-        assertEq(morpho.expectedSupplyBalance(allMarkets[0], address(vault)), 0, "expectedSupplyBalance(vault)");
+        assertEq(morpho.expectedSupplyAssets(allMarkets[0], address(vault)), 0, "expectedSupplyAssets(vault)");
     }
 
     function testRedeemNotDeposited(uint256 deposited) public {

--- a/test/forge/ReallocateIdleTest.sol
+++ b/test/forge/ReallocateIdleTest.sol
@@ -12,7 +12,7 @@ contract ReallocateIdleTest is IntegrationTest {
     using MarketParamsLib for MarketParams;
     using MorphoLib for IMorpho;
 
-    MarketAllocation[] internal totalAllocation;
+    MarketAllocation[] internal allocations;
 
     function setUp() public override {
         super.setUp();
@@ -35,14 +35,14 @@ contract ReallocateIdleTest is IntegrationTest {
         suppliedAssets[1] = bound(suppliedAssets[1], 1, CAP2);
         suppliedAssets[2] = bound(suppliedAssets[2], 1, CAP2);
 
-        totalAllocation.push(MarketAllocation(allMarkets[0], suppliedAssets[0]));
-        totalAllocation.push(MarketAllocation(allMarkets[1], suppliedAssets[1]));
-        totalAllocation.push(MarketAllocation(allMarkets[2], suppliedAssets[2]));
+        allocations.push(MarketAllocation(allMarkets[0], suppliedAssets[0]));
+        allocations.push(MarketAllocation(allMarkets[1], suppliedAssets[1]));
+        allocations.push(MarketAllocation(allMarkets[2], suppliedAssets[2]));
 
         uint256 idleBefore = vault.idle();
 
         vm.prank(ALLOCATOR);
-        vault.reallocate(totalAllocation);
+        vault.reallocate(allocations);
 
         assertEq(
             morpho.supplyShares(allMarkets[0].id(), address(vault)),

--- a/test/forge/ReallocateIdleTest.sol
+++ b/test/forge/ReallocateIdleTest.sol
@@ -12,8 +12,7 @@ contract ReallocateIdleTest is IntegrationTest {
     using MarketParamsLib for MarketParams;
     using MorphoLib for IMorpho;
 
-    MarketAllocation[] internal withdrawn;
-    MarketAllocation[] internal supplied;
+    MarketAllocation[] internal totalAllocation;
 
     function setUp() public override {
         super.setUp();
@@ -36,14 +35,14 @@ contract ReallocateIdleTest is IntegrationTest {
         suppliedAssets[1] = bound(suppliedAssets[1], 1, CAP2);
         suppliedAssets[2] = bound(suppliedAssets[2], 1, CAP2);
 
-        supplied.push(MarketAllocation(allMarkets[0], suppliedAssets[0]));
-        supplied.push(MarketAllocation(allMarkets[1], suppliedAssets[1]));
-        supplied.push(MarketAllocation(allMarkets[2], suppliedAssets[2]));
+        totalAllocation.push(MarketAllocation(allMarkets[0], suppliedAssets[0]));
+        totalAllocation.push(MarketAllocation(allMarkets[1], suppliedAssets[1]));
+        totalAllocation.push(MarketAllocation(allMarkets[2], suppliedAssets[2]));
 
         uint256 idleBefore = vault.idle();
 
         vm.prank(ALLOCATOR);
-        vault.reallocate(withdrawn, supplied);
+        vault.reallocate(totalAllocation);
 
         assertEq(
             morpho.supplyShares(allMarkets[0].id(), address(vault)),

--- a/test/forge/ReallocateWithdrawTest.sol
+++ b/test/forge/ReallocateWithdrawTest.sol
@@ -46,9 +46,19 @@ contract ReallocateWithdrawTest is IntegrationTest {
     }
 
     function testReallocateWithdrawInconsistentAsset() public {
-        allMarkets[0].loanToken = address(1);
+        ERC20Mock loanToken2 = new ERC20Mock("loan2", "B2");
+        allMarkets[0].loanToken = address(loanToken2);
 
-        allocations.push(MarketAllocation(allMarkets[0], 1));
+        morpho.createMarket(allMarkets[0]);
+
+        loanToken2.setBalance(SUPPLIER, 1);
+
+        vm.startPrank(SUPPLIER);
+        loanToken2.approve(address(morpho), type(uint256).max);
+        morpho.supply(allMarkets[0], 1, 0, address(vault), hex"");
+        vm.stopPrank();
+
+        allocations.push(MarketAllocation(allMarkets[0], 0));
 
         vm.prank(ALLOCATOR);
         vm.expectRevert(abi.encodeWithSelector(ErrorsLib.InconsistentAsset.selector, allMarkets[0].id()));

--- a/test/forge/ReallocateWithdrawTest.sol
+++ b/test/forge/ReallocateWithdrawTest.sol
@@ -16,8 +16,7 @@ contract ReallocateWithdrawTest is IntegrationTest {
     using SharesMathLib for uint256;
     using UtilsLib for uint256;
 
-    MarketAllocation[] internal withdrawn;
-    MarketAllocation[] internal supplied;
+    MarketAllocation[] internal totalAllocation;
 
     function setUp() public override {
         super.setUp();
@@ -33,12 +32,12 @@ contract ReallocateWithdrawTest is IntegrationTest {
     }
 
     function testReallocateWithdrawMax() public {
-        withdrawn.push(MarketAllocation(allMarkets[0], type(uint256).max));
-        withdrawn.push(MarketAllocation(allMarkets[1], type(uint256).max));
-        withdrawn.push(MarketAllocation(allMarkets[2], type(uint256).max));
+        totalAllocation.push(MarketAllocation(allMarkets[0], 0));
+        totalAllocation.push(MarketAllocation(allMarkets[1], 0));
+        totalAllocation.push(MarketAllocation(allMarkets[2], 0));
 
         vm.prank(ALLOCATOR);
-        vault.reallocate(withdrawn, supplied);
+        vault.reallocate(totalAllocation);
 
         assertEq(morpho.supplyShares(allMarkets[0].id(), address(vault)), 0, "morpho.supplyShares(0)");
         assertEq(morpho.supplyShares(allMarkets[1].id(), address(vault)), 0, "morpho.supplyShares(1)");
@@ -49,89 +48,47 @@ contract ReallocateWithdrawTest is IntegrationTest {
     function testReallocateWithdrawInconsistentAsset() public {
         allMarkets[0].loanToken = address(1);
 
-        withdrawn.push(MarketAllocation(allMarkets[0], 0));
+        totalAllocation.push(MarketAllocation(allMarkets[0], 1));
 
         vm.prank(ALLOCATOR);
         vm.expectRevert(abi.encodeWithSelector(ErrorsLib.InconsistentAsset.selector, allMarkets[0].id()));
-        vault.reallocate(withdrawn, supplied);
+        vault.reallocate(totalAllocation);
     }
 
-    function testReallocateWithdrawSupply(uint256[3] memory withdrawnAssets, uint256[3] memory suppliedAssets) public {
-        uint256[3] memory sharesBefore = [
-            morpho.supplyShares(allMarkets[0].id(), address(vault)),
-            morpho.supplyShares(allMarkets[1].id(), address(vault)),
-            morpho.supplyShares(allMarkets[2].id(), address(vault))
-        ];
-
+    function testReallocateWithdrawSupply(uint256[3] memory assets) public {
         uint256[3] memory totalSupplyAssets;
         uint256[3] memory totalSupplyShares;
         (totalSupplyAssets[0], totalSupplyShares[0],,) = morpho.expectedMarketBalances(allMarkets[0]);
         (totalSupplyAssets[1], totalSupplyShares[1],,) = morpho.expectedMarketBalances(allMarkets[1]);
         (totalSupplyAssets[2], totalSupplyShares[2],,) = morpho.expectedMarketBalances(allMarkets[2]);
 
-        withdrawnAssets[0] =
-            bound(withdrawnAssets[0], 0, sharesBefore[0].toAssetsDown(totalSupplyAssets[0], totalSupplyShares[0]));
-        withdrawnAssets[1] =
-            bound(withdrawnAssets[1], 0, sharesBefore[1].toAssetsDown(totalSupplyAssets[1], totalSupplyShares[1]));
-        withdrawnAssets[2] =
-            bound(withdrawnAssets[2], 0, sharesBefore[2].toAssetsDown(totalSupplyAssets[2], totalSupplyShares[2]));
+        assets[0] = bound(assets[0], 0, CAP2);
+        assets[1] = bound(assets[1], 0, CAP2);
+        assets[2] = bound(assets[2], 0, CAP2);
 
-        uint256[3] memory withdrawnShares = [
-            withdrawnAssets[0].toSharesUp(totalSupplyAssets[0], totalSupplyShares[0]),
-            withdrawnAssets[1].toSharesUp(totalSupplyAssets[1], totalSupplyShares[1]),
-            withdrawnAssets[2].toSharesUp(totalSupplyAssets[2], totalSupplyShares[2])
-        ];
+        totalAllocation.push(MarketAllocation(allMarkets[0], assets[0]));
+        totalAllocation.push(MarketAllocation(allMarkets[1], assets[1]));
+        totalAllocation.push(MarketAllocation(allMarkets[2], assets[2]));
 
-        if (withdrawnAssets[0] > 0) withdrawn.push(MarketAllocation(allMarkets[0], withdrawnAssets[0]));
-        if (withdrawnAssets[1] > 0) withdrawn.push(MarketAllocation(allMarkets[1], withdrawnAssets[1]));
-        if (withdrawnAssets[2] > 0) withdrawn.push(MarketAllocation(allMarkets[2], withdrawnAssets[2]));
-
-        totalSupplyAssets[0] -= withdrawnAssets[0];
-        totalSupplyAssets[1] -= withdrawnAssets[1];
-        totalSupplyAssets[2] -= withdrawnAssets[2];
-
-        totalSupplyShares[0] -= withdrawnShares[0];
-        totalSupplyShares[1] -= withdrawnShares[1];
-        totalSupplyShares[2] -= withdrawnShares[2];
-
-        uint256 expectedIdle = vault.idle() + withdrawnAssets[0] + withdrawnAssets[1] + withdrawnAssets[2];
-
-        suppliedAssets[0] = bound(suppliedAssets[0], 0, withdrawnAssets[0].zeroFloorSub(CAP2).min(expectedIdle));
-        expectedIdle -= suppliedAssets[0];
-
-        suppliedAssets[1] = bound(suppliedAssets[1], 0, withdrawnAssets[1].zeroFloorSub(CAP2).min(expectedIdle));
-        expectedIdle -= suppliedAssets[1];
-
-        suppliedAssets[2] = bound(suppliedAssets[2], 0, withdrawnAssets[2].zeroFloorSub(CAP2).min(expectedIdle));
-        expectedIdle -= suppliedAssets[2];
-
-        uint256[3] memory suppliedShares = [
-            suppliedAssets[0].toSharesDown(totalSupplyAssets[0], totalSupplyShares[0]),
-            suppliedAssets[1].toSharesDown(totalSupplyAssets[1], totalSupplyShares[1]),
-            suppliedAssets[2].toSharesDown(totalSupplyAssets[2], totalSupplyShares[2])
-        ];
-
-        if (suppliedAssets[0] > 0) supplied.push(MarketAllocation(allMarkets[0], suppliedAssets[0]));
-        if (suppliedAssets[1] > 0) supplied.push(MarketAllocation(allMarkets[1], suppliedAssets[1]));
-        if (suppliedAssets[2] > 0) supplied.push(MarketAllocation(allMarkets[2], suppliedAssets[2]));
+        uint256 expectedIdle = vault.idle() + 3 * CAP2 - assets[0] - assets[1] - assets[2];
 
         vm.prank(ALLOCATOR);
-        vault.reallocate(withdrawn, supplied);
+        vault.reallocate(totalAllocation);
 
         assertEq(
             morpho.supplyShares(allMarkets[0].id(), address(vault)),
-            sharesBefore[0] - withdrawnShares[0] + suppliedShares[0],
+            assets[0] * SharesMathLib.VIRTUAL_SHARES,
             "morpho.supplyShares(0)"
         );
         assertApproxEqAbs(
             morpho.supplyShares(allMarkets[1].id(), address(vault)),
-            sharesBefore[1] - withdrawnShares[1] + suppliedShares[1],
+            assets[1] * SharesMathLib.VIRTUAL_SHARES,
             SharesMathLib.VIRTUAL_SHARES,
             "morpho.supplyShares(1)"
         );
         assertEq(
             morpho.supplyShares(allMarkets[2].id(), address(vault)),
-            sharesBefore[2] - withdrawnShares[2] + suppliedShares[2],
+            assets[2] * SharesMathLib.VIRTUAL_SHARES,
             "morpho.supplyShares(2)"
         );
         assertApproxEqAbs(vault.idle(), expectedIdle, 1, "vault.idle() 1");
@@ -144,29 +101,29 @@ contract ReallocateWithdrawTest is IntegrationTest {
 
         _setCap(allMarkets[1], 0);
 
-        withdrawn.push(MarketAllocation(allMarkets[0], type(uint256).max));
-        withdrawn.push(MarketAllocation(allMarkets[1], type(uint256).max));
-        withdrawn.push(MarketAllocation(allMarkets[2], type(uint256).max));
+        totalAllocation.push(MarketAllocation(allMarkets[0], 0));
+        totalAllocation.push(MarketAllocation(allMarkets[1], 0));
+        totalAllocation.push(MarketAllocation(allMarkets[2], 0));
 
-        supplied.push(MarketAllocation(allMarkets[0], suppliedAssets[0]));
-        supplied.push(MarketAllocation(allMarkets[1], suppliedAssets[1]));
-        supplied.push(MarketAllocation(allMarkets[2], suppliedAssets[2]));
+        totalAllocation.push(MarketAllocation(allMarkets[0], suppliedAssets[0]));
+        totalAllocation.push(MarketAllocation(allMarkets[1], suppliedAssets[1]));
+        totalAllocation.push(MarketAllocation(allMarkets[2], suppliedAssets[2]));
 
         vm.prank(ALLOCATOR);
         vm.expectRevert(abi.encodeWithSelector(ErrorsLib.UnauthorizedMarket.selector, allMarkets[1].id()));
-        vault.reallocate(withdrawn, supplied);
+        vault.reallocate(totalAllocation);
     }
 
     function testReallocateSupplyCapExceeded() public {
-        withdrawn.push(MarketAllocation(allMarkets[0], type(uint256).max));
-        withdrawn.push(MarketAllocation(allMarkets[1], type(uint256).max));
-        withdrawn.push(MarketAllocation(allMarkets[2], type(uint256).max));
+        totalAllocation.push(MarketAllocation(allMarkets[0], 0));
+        totalAllocation.push(MarketAllocation(allMarkets[1], 0));
+        totalAllocation.push(MarketAllocation(allMarkets[2], 0));
 
-        supplied.push(MarketAllocation(allMarkets[0], CAP2 + 1));
+        totalAllocation.push(MarketAllocation(allMarkets[0], CAP2 + 1));
 
         vm.prank(ALLOCATOR);
         vm.expectRevert(abi.encodeWithSelector(ErrorsLib.SupplyCapExceeded.selector, allMarkets[0].id()));
-        vault.reallocate(withdrawn, supplied);
+        vault.reallocate(totalAllocation);
     }
 
     function testReallocateInsufficientIdle(uint256 rewards) public {
@@ -179,10 +136,10 @@ contract ReallocateWithdrawTest is IntegrationTest {
 
         _setCap(allMarkets[0], type(uint192).max);
 
-        supplied.push(MarketAllocation(allMarkets[0], CAP2 + rewards));
+        totalAllocation.push(MarketAllocation(allMarkets[0], 2 * CAP2 + rewards));
 
         vm.prank(ALLOCATOR);
         vm.expectRevert(ErrorsLib.InsufficientIdle.selector);
-        vault.reallocate(withdrawn, supplied);
+        vault.reallocate(totalAllocation);
     }
 }

--- a/test/forge/RoleTest.sol
+++ b/test/forge/RoleTest.sol
@@ -102,7 +102,7 @@ contract RoleTest is IntegrationTest {
         vault.sortWithdrawQueue(withdrawQueueFromRanks);
 
         vm.expectRevert(ErrorsLib.NotAllocatorRole.selector);
-        vault.reallocate(allocation, allocation);
+        vault.reallocate(allocation);
 
         vm.stopPrank();
     }
@@ -129,17 +129,17 @@ contract RoleTest is IntegrationTest {
         vm.startPrank(OWNER);
         vault.setSupplyQueue(supplyQueue);
         vault.sortWithdrawQueue(withdrawQueueFromRanks);
-        vault.reallocate(allocation, allocation);
+        vault.reallocate(allocation);
 
         vm.startPrank(CURATOR);
         vault.setSupplyQueue(supplyQueue);
         vault.sortWithdrawQueue(withdrawQueueFromRanks);
-        vault.reallocate(allocation, allocation);
+        vault.reallocate(allocation);
 
         vm.startPrank(ALLOCATOR);
         vault.setSupplyQueue(supplyQueue);
         vault.sortWithdrawQueue(withdrawQueueFromRanks);
-        vault.reallocate(allocation, allocation);
+        vault.reallocate(allocation);
         vm.stopPrank();
     }
 }

--- a/test/hardhat/MetaMorpho.spec.ts
+++ b/test/hardhat/MetaMorpho.spec.ts
@@ -276,13 +276,13 @@ describe("MetaMorpho", () => {
 
       const marketAssets = (withdrawnAssets * 9n) / 10n / toBigInt(nbMarkets);
 
-      const totalAllocation = withdrawnAllocation.map(({ marketParams, remaining }) => ({
+      const allocations = withdrawnAllocation.map(({ marketParams, remaining }) => ({
         marketParams,
         // Always supply evenly on each market 90% of what the vault withdrawn in total.
         assets: remaining + marketAssets,
       }));
 
-      await metaMorpho.connect(allocator).reallocate(totalAllocation);
+      await metaMorpho.connect(allocator).reallocate(allocations);
 
       // Borrow liquidity to generate interest.
 


### PR DESCRIPTION
With this change, the allocator role is responsible for ordering input allocations so as to have sufficient liquidity at each supply step