### PR TITLE
Enable tracking the accrued interest

### DIFF
--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -823,14 +823,14 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
     }
 
     /// @dev Accrues the fee and mints the fee shares to the fee recipient.
-    /// @return newTotalAssets The new vault's total assets.
-    function _accrueFee() internal returns (uint256 newTotalAssets) {
+    /// @return accruedTotalAssets The vaults total assets after accruing the interest.
+    function _accrueFee() internal returns (uint256 accruedTotalAssets) {
         uint256 feeShares;
-        (feeShares, newTotalAssets) = _accruedFeeShares();
+        (feeShares, accruedTotalAssets) = _accruedFeeShares();
 
         if (feeShares != 0) _mint(feeRecipient, feeShares);
 
-        emit EventsLib.AccrueInterest(lastTotalAssets, newTotalAssets, feeShares);
+        emit EventsLib.AccrueInterest(lastTotalAssets, accruedTotalAssets, feeShares);
     }
 
     /// @dev Computes and returns the fee shares (`feeShares`) to mint and the new vault's total assets

--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -828,11 +828,9 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
         uint256 feeShares;
         (feeShares, newTotalAssets) = _accruedFeeShares();
 
-        if (feeShares != 0) {
-            _mint(feeRecipient, feeShares);
+        if (feeShares != 0) _mint(feeRecipient, feeShares);
 
-            emit EventsLib.AccrueFee(feeShares);
-        }
+        emit EventsLib.AccrueInterest(lastTotalAssets, newTotalAssets, feeShares);
     }
 
     /// @dev Computes and returns the fee shares (`feeShares`) to mint and the new vault's total assets

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -79,7 +79,10 @@ library EventsLib {
     event ReallocateIdle(address indexed caller, uint256 idle);
 
     /// @notice Emitted when fees are accrued.
-    event AccrueFee(uint256 feeShares);
+    /// @param lastTotalAssets The assets of the vault before the interaction.
+    /// @param newTotalAssets The assets of the vault after accruing the interest but before the interaction.
+    /// @param feeShares The shares minted to the fee recipient.
+    event AccrueInterest(uint256 lastTotalAssets, uint256 newTotalAssets, uint256 feeShares);
 
     /// @notice Emitted when an `amount` of `token` is transferred to the `rewardsRecipient` by `caller`.
     event TransferRewards(address indexed caller, address indexed token, uint256 amount);

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -80,9 +80,9 @@ library EventsLib {
 
     /// @notice Emitted when fees are accrued.
     /// @param lastTotalAssets The assets of the vault before the interaction.
-    /// @param newTotalAssets The assets of the vault after accruing the interest but before the interaction.
+    /// @param accruedTotalAssets The assets of the vault after accruing the interest but before the interaction.
     /// @param feeShares The shares minted to the fee recipient.
-    event AccrueInterest(uint256 lastTotalAssets, uint256 newTotalAssets, uint256 feeShares);
+    event AccrueInterest(uint256 lastTotalAssets, uint256 accruedTotalAssets, uint256 feeShares);
 
     /// @notice Emitted when an `amount` of `token` is transferred to the `rewardsRecipient` by `caller`.
     event TransferRewards(address indexed caller, address indexed token, uint256 amount);

--- a/test/forge/FeeTest.sol
+++ b/test/forge/FeeTest.sol
@@ -93,6 +93,8 @@ contract FeeTest is IntegrationTest {
 
         _forward(blocks);
 
+        uint256 totalAssetsAfter = vault.totalAssets();
+
         uint256 feeShares = _feeShares(totalAssetsBefore);
         vm.assume(feeShares != 0);
 
@@ -100,7 +102,7 @@ contract FeeTest is IntegrationTest {
 
         vm.prank(SUPPLIER);
         vm.expectEmit();
-        emit EventsLib.AccrueFee(feeShares);
+        emit EventsLib.AccrueInterest(totalAssetsBefore, totalAssetsAfter, feeShares);
 
         vault.deposit(newDeposit, ONBEHALF);
 
@@ -122,6 +124,8 @@ contract FeeTest is IntegrationTest {
 
         _forward(blocks);
 
+        uint256 totalAssetsAfter = vault.totalAssets();
+
         uint256 feeShares = _feeShares(totalAssetsBefore);
         vm.assume(feeShares != 0);
 
@@ -131,7 +135,7 @@ contract FeeTest is IntegrationTest {
 
         vm.prank(SUPPLIER);
         vm.expectEmit();
-        emit EventsLib.AccrueFee(feeShares);
+        emit EventsLib.AccrueInterest(totalAssetsBefore, totalAssetsAfter, feeShares);
 
         vault.mint(shares, ONBEHALF);
 
@@ -153,6 +157,8 @@ contract FeeTest is IntegrationTest {
 
         _forward(blocks);
 
+        uint256 totalAssetsAfter = vault.totalAssets();
+
         uint256 feeShares = _feeShares(totalAssetsBefore);
         vm.assume(feeShares != 0);
 
@@ -160,7 +166,7 @@ contract FeeTest is IntegrationTest {
 
         vm.prank(ONBEHALF);
         vm.expectEmit();
-        emit EventsLib.AccrueFee(feeShares);
+        emit EventsLib.AccrueInterest(totalAssetsBefore, totalAssetsAfter, feeShares);
 
         vault.redeem(shares, RECEIVER, ONBEHALF);
 
@@ -182,12 +188,14 @@ contract FeeTest is IntegrationTest {
 
         _forward(blocks);
 
+        uint256 totalAssetsAfter = vault.totalAssets();
+
         uint256 feeShares = _feeShares(totalAssetsBefore);
         vm.assume(feeShares != 0);
 
         vm.prank(ONBEHALF);
         vm.expectEmit();
-        emit EventsLib.AccrueFee(feeShares);
+        emit EventsLib.AccrueInterest(totalAssetsBefore, totalAssetsAfter, feeShares);
 
         vault.withdraw(withdrawn, RECEIVER, ONBEHALF);
 
@@ -209,11 +217,13 @@ contract FeeTest is IntegrationTest {
 
         _forward(blocks);
 
+        uint256 totalAssetsAfter = vault.totalAssets();
+
         uint256 feeShares = _feeShares(totalAssetsBefore);
         vm.assume(feeShares != 0);
 
         vm.expectEmit();
-        emit EventsLib.AccrueFee(feeShares);
+        emit EventsLib.AccrueInterest(totalAssetsBefore, totalAssetsAfter, feeShares);
         _setFee(fee);
 
         assertEq(vault.lastTotalAssets(), vault.totalAssets(), "lastTotalAssets");
@@ -233,17 +243,19 @@ contract FeeTest is IntegrationTest {
 
         _forward(blocks);
 
+        uint256 totalAssetsAfter = vault.totalAssets();
+
         uint256 feeShares = _feeShares(totalAssetsBefore);
         vm.assume(feeShares != 0);
 
         vm.expectEmit();
-        emit EventsLib.AccrueFee(feeShares);
-        emit EventsLib.UpdateLastTotalAssets(vault.totalAssets());
+        emit EventsLib.AccrueInterest(totalAssetsBefore, totalAssetsAfter, feeShares);
+        emit EventsLib.UpdateLastTotalAssets(totalAssetsAfter);
         emit EventsLib.SetFeeRecipient(address(1));
         vm.prank(OWNER);
         vault.setFeeRecipient(address(1));
 
-        assertEq(vault.lastTotalAssets(), vault.totalAssets(), "lastTotalAssets");
+        assertEq(vault.lastTotalAssets(), totalAssetsAfter, "lastTotalAssets");
         assertEq(vault.balanceOf(FEE_RECIPIENT), feeShares, "vault.balanceOf(FEE_RECIPIENT)");
         assertEq(vault.balanceOf(address(1)), 0, "vault.balanceOf(address(1))");
     }

--- a/test/forge/FeeTest.sol
+++ b/test/forge/FeeTest.sol
@@ -226,7 +226,7 @@ contract FeeTest is IntegrationTest {
         emit EventsLib.AccrueInterest(totalAssetsBefore, totalAssetsAfter, feeShares);
         _setFee(fee);
 
-        assertEq(vault.lastTotalAssets(), vault.totalAssets(), "lastTotalAssets");
+        assertEq(vault.lastTotalAssets(), totalAssetsAfter, "lastTotalAssets");
         assertEq(vault.balanceOf(FEE_RECIPIENT), feeShares, "vault.balanceOf(FEE_RECIPIENT)");
     }
 


### PR DESCRIPTION
Motivated by a remark of @tomrpl, thanks !

Before this PR, the events `AccrueFee(uint256 feeShares)` and `UpdateLastTotalAssets(uint256 newTotalAssets)` were emitted at each interaction. Those are not enough to compute the actual yield generated by the vault because:
- `feeShares` could be 0, if the vault does not take any performance fee we can't recompute the whole interest generated
- `newTotalAssets` takes into account the funds added by the current interaction. Those funds are not part of the interest generated and are difficult to subtract (it depends on each interaction)

To fix this, the event `AccrueFee` is transformed into `AccrueInterest` to add 2 fields:
1. `lastTotalAssets`, the value of the storage variable of the same name before the interaction. It is provided as a convenience to be able to reconstruct the yield by looking only at events
2. `accruedTotalAssets`, the total assets in the vault before the interaction, after having accrued the interest

With those, one can compute `(accruedTotalAssets - lastTotalAssets) / lastTotalAssets` to compute the yield generated during 2 interactions.