### PR TITLE
Add libs explicitly to foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,7 @@
 [profile.default]
 src = "src"
 test = "test/forge"
+libs = ["lib"]
 evm_version = "paris"
 fs_permissions = [
     { access = "read", path = "./config/"},


### PR DESCRIPTION
The goal is to make so the installation does not mess the git state. Before this PR, if you start from a fresh repository you would have git show some changes on the `foundry.toml` file. Repro: `rm -rf lib && forge install`, and then check that you have changes with `git status`