### PR TITLE
perf(setCap): use market params

### DIFF
--- a/src/interfaces/IMetaMorpho.sol
+++ b/src/interfaces/IMetaMorpho.sol
@@ -52,10 +52,10 @@ interface IMetaMorphoBase {
     function revokePendingTimelock() external;
 
     function submitCap(MarketParams memory marketParams, uint256 supplyCap) external;
-    function acceptCap(Id id) external;
+    function acceptCap(MarketParams memory marketParams) external;
     function revokePendingCap(Id id) external;
 
-    function submitMarketRemoval(Id id) external;
+    function submitMarketRemoval(MarketParams memory marketParams) external;
     function revokePendingMarketRemoval(Id id) external;
 
     function submitGuardian(address newGuardian) external;

--- a/test/forge/GuardianTest.sol
+++ b/test/forge/GuardianTest.sol
@@ -129,7 +129,7 @@ contract GuardianTest is IntegrationTest {
         _setCap(marketParams, 0);
 
         vm.prank(CURATOR);
-        vault.submitMarketRemoval(id);
+        vault.submitMarketRemoval(allMarkets[0]);
 
         vm.warp(block.timestamp + elapsed);
 

--- a/test/forge/MarketTest.sol
+++ b/test/forge/MarketTest.sol
@@ -117,7 +117,7 @@ contract MarketTest is IntegrationTest {
         vm.warp(block.timestamp + 1 weeks);
 
         vm.expectRevert(ErrorsLib.MaxQueueLengthExceeded.selector);
-        vault.acceptCap(marketParams.id());
+        vault.acceptCap(marketParams);
     }
 
     function testSetSupplyQueueUnauthorizedMarket() public {
@@ -157,7 +157,7 @@ contract MarketTest is IntegrationTest {
         _setCap(allMarkets[2], 0);
 
         vm.prank(CURATOR);
-        vault.submitMarketRemoval(allMarkets[2].id());
+        vault.submitMarketRemoval(allMarkets[2]);
 
         vm.warp(block.timestamp + TIMELOCK);
 
@@ -186,7 +186,7 @@ contract MarketTest is IntegrationTest {
         vm.expectEmit();
         emit EventsLib.SubmitMarketRemoval(CURATOR, allMarkets[2].id());
         vm.prank(CURATOR);
-        vault.submitMarketRemoval(allMarkets[2].id());
+        vault.submitMarketRemoval(allMarkets[2]);
 
         assertEq(vault.config(allMarkets[2].id()).cap, 0);
         assertEq(vault.config(allMarkets[2].id()).removableAt, block.timestamp + TIMELOCK);
@@ -194,9 +194,9 @@ contract MarketTest is IntegrationTest {
 
     function testSubmitMarketRemovalAlreadySet() public {
         vm.startPrank(CURATOR);
-        vault.submitMarketRemoval(allMarkets[2].id());
+        vault.submitMarketRemoval(allMarkets[2]);
         vm.expectRevert(ErrorsLib.AlreadySet.selector);
-        vault.submitMarketRemoval(allMarkets[2].id());
+        vault.submitMarketRemoval(allMarkets[2]);
         vm.stopPrank();
     }
 
@@ -265,7 +265,7 @@ contract MarketTest is IntegrationTest {
         _setCap(idleParams, 0);
 
         vm.prank(CURATOR);
-        vault.submitMarketRemoval(idleParams.id());
+        vault.submitMarketRemoval(idleParams);
 
         vm.warp(block.timestamp + elapsed);
 

--- a/test/forge/MetaMorphoInternalTest.sol
+++ b/test/forge/MetaMorphoInternalTest.sol
@@ -16,21 +16,18 @@ contract MetaMorphoInternalTest is InternalTest {
 
     function testSetCapMaxQueueLengthExcedeed() public {
         for (uint256 i; i < NB_MARKETS - 1; ++i) {
-            Id id = allMarkets[i].id();
-            _setCap(id, CAP);
+            _setCap(allMarkets[i], allMarkets[i].id(), CAP);
         }
 
-        Id lastId = allMarkets[NB_MARKETS - 1].id();
         vm.expectRevert(ErrorsLib.MaxQueueLengthExceeded.selector);
-        _setCap(lastId, CAP);
+        _setCap(allMarkets[NB_MARKETS - 1], allMarkets[NB_MARKETS - 1].id(), CAP);
     }
 
     function testSimulateWithdraw(uint256 suppliedAmount, uint256 borrowedAmount, uint256 assets) public {
         suppliedAmount = bound(suppliedAmount, MIN_TEST_ASSETS, MAX_TEST_ASSETS);
         borrowedAmount = bound(borrowedAmount, MIN_TEST_ASSETS, suppliedAmount);
 
-        Id id = allMarkets[0].id();
-        _setCap(id, CAP);
+        _setCap(allMarkets[0], allMarkets[0].id(), CAP);
 
         loanToken.setBalance(SUPPLIER, suppliedAmount);
         vm.prank(SUPPLIER);

--- a/test/forge/TimelockTest.sol
+++ b/test/forge/TimelockTest.sol
@@ -352,7 +352,7 @@ contract TimelockTest is IntegrationTest {
 
         vm.expectEmit(address(vault));
         emit EventsLib.SetCap(address(this), id, cap);
-        vault.acceptCap(id);
+        vault.acceptCap(marketParams);
 
         MarketConfig memory marketConfig = vault.config(id);
         PendingUint192 memory pendingCap = vault.pendingCap(id);
@@ -383,7 +383,7 @@ contract TimelockTest is IntegrationTest {
 
         vm.expectEmit();
         emit EventsLib.SetCap(address(this), id, cap);
-        vault.acceptCap(id);
+        vault.acceptCap(marketParams);
 
         MarketConfig memory marketConfig = vault.config(id);
         PendingUint192 memory pendingCap = vault.pendingCap(id);
@@ -408,7 +408,6 @@ contract TimelockTest is IntegrationTest {
         vm.warp(block.timestamp + elapsed);
 
         MarketParams memory marketParams = allMarkets[0];
-        Id id = marketParams.id();
 
         vm.prank(CURATOR);
         vault.submitCap(marketParams, cap);
@@ -418,12 +417,12 @@ contract TimelockTest is IntegrationTest {
         vault.acceptTimelock();
 
         vm.expectRevert(ErrorsLib.TimelockNotElapsed.selector);
-        vault.acceptCap(id);
+        vault.acceptCap(marketParams);
     }
 
     function testAcceptCapNoPendingValue() public {
         vm.expectRevert(ErrorsLib.NoPendingValue.selector);
-        vault.acceptCap(allMarkets[0].id());
+        vault.acceptCap(allMarkets[0]);
     }
 
     function testAcceptCapTimelockNotElapsed(uint256 elapsed) public {
@@ -435,7 +434,7 @@ contract TimelockTest is IntegrationTest {
         vm.warp(block.timestamp + elapsed);
 
         vm.expectRevert(ErrorsLib.TimelockNotElapsed.selector);
-        vault.acceptCap(allMarkets[1].id());
+        vault.acceptCap(allMarkets[1]);
     }
 
     function testSubmitMarketRemoval() public {
@@ -445,7 +444,7 @@ contract TimelockTest is IntegrationTest {
         _setCap(marketParams, 0);
 
         vm.prank(CURATOR);
-        vault.submitMarketRemoval(id);
+        vault.submitMarketRemoval(marketParams);
 
         MarketConfig memory marketConfig = vault.config(id);
 
@@ -457,6 +456,6 @@ contract TimelockTest is IntegrationTest {
     function testSubmitMarketRemovalMarketNotEnabled() public {
         vm.expectRevert(ErrorsLib.MarketNotEnabled.selector);
         vm.prank(CURATOR);
-        vault.submitMarketRemoval(allMarkets[1].id());
+        vault.submitMarketRemoval(allMarkets[1]);
     }
 }

--- a/test/forge/helpers/IntegrationTest.sol
+++ b/test/forge/helpers/IntegrationTest.sol
@@ -112,7 +112,7 @@ contract IntegrationTest is BaseTest {
 
         vm.warp(block.timestamp + vault.timelock());
 
-        vault.acceptCap(id);
+        vault.acceptCap(marketParams);
 
         assertEq(vault.config(id).cap, newCap, "_setCap");
     }

--- a/test/hardhat/MetaMorpho.spec.ts
+++ b/test/hardhat/MetaMorpho.spec.ts
@@ -2,7 +2,7 @@ import { AbiCoder, MaxUint256, ZeroAddress, ZeroHash, keccak256, toBigInt } from
 import hre from "hardhat";
 import _range from "lodash/range";
 import { ERC20Mock, OracleMock, MetaMorpho, IMorpho, MetaMorphoFactory, MetaMorpho__factory, IrmMock } from "types";
-import { MarketParamsStruct } from "types/@morpho-blue/interfaces/IMorpho";
+import { MarketParamsStruct } from "types/src/MetaMorpho";
 
 import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { mine } from "@nomicfoundation/hardhat-network-helpers";
@@ -224,10 +224,10 @@ describe("MetaMorpho", () => {
 
     await forwardTimestamp(timelock);
 
-    await metaMorpho.connect(admin).acceptCap(identifier(idleParams));
+    await metaMorpho.connect(admin).acceptCap(idleParams);
 
     for (const marketParams of allMarketParams) {
-      await metaMorpho.connect(admin).acceptCap(identifier(marketParams));
+      await metaMorpho.connect(admin).acceptCap(marketParams);
     }
 
     await metaMorpho.connect(curator).setSupplyQueue(


### PR DESCRIPTION
it saves 10k for the `acceptCap` function (>5%)