### PR TITLE
fix(reallocate): prevent withdrawing from market not enabled

### DIFF
--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -63,7 +63,7 @@ library ErrorsLib {
     /// @notice Thrown when submitting a cap for a market which does not exist.
     error MarketNotCreated();
 
-    /// @notice Thrown when submitting a non previously enabled market for removal.
+    /// @notice Thrown when interacting with a non previously enabled market `id`.
     error MarketNotEnabled(Id id);
 
     /// @notice Thrown when the submitted timelock is above the max timelock.

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -64,7 +64,7 @@ library ErrorsLib {
     error MarketNotCreated();
 
     /// @notice Thrown when submitting a non previously enabled market for removal.
-    error MarketNotEnabled();
+    error MarketNotEnabled(Id id);
 
     /// @notice Thrown when the submitted timelock is above the max timelock.
     error AboveMaxTimelock();

--- a/test/forge/ReallocateWithdrawTest.sol
+++ b/test/forge/ReallocateWithdrawTest.sol
@@ -59,7 +59,7 @@ contract ReallocateWithdrawTest is IntegrationTest {
         assertEq(_idle(), INITIAL_DEPOSIT, "idle");
     }
 
-    function testReallocateWithdrawInconsistentAsset() public {
+    function testReallocateWithdrawMarketNotEnabled() public {
         ERC20Mock loanToken2 = new ERC20Mock("loan2", "B2");
         allMarkets[0].loanToken = address(loanToken2);
 
@@ -75,7 +75,7 @@ contract ReallocateWithdrawTest is IntegrationTest {
         allocations.push(MarketAllocation(allMarkets[0], 0));
 
         vm.prank(ALLOCATOR);
-        vm.expectRevert(abi.encodeWithSelector(ErrorsLib.InconsistentAsset.selector, allMarkets[0].id()));
+        vm.expectRevert(abi.encodeWithSelector(ErrorsLib.MarketNotEnabled.selector, allMarkets[0].id()));
         vault.reallocate(allocations);
     }
 

--- a/test/forge/TimelockTest.sol
+++ b/test/forge/TimelockTest.sol
@@ -455,7 +455,7 @@ contract TimelockTest is IntegrationTest {
     }
 
     function testSubmitMarketRemovalMarketNotEnabled() public {
-        vm.expectRevert(ErrorsLib.MarketNotEnabled.selector);
+        vm.expectRevert(abi.encodeWithSelector(ErrorsLib.MarketNotEnabled.selector, allMarkets[1].id()));
         vm.prank(CURATOR);
         vault.submitMarketRemoval(allMarkets[1].id());
     }


### PR DESCRIPTION
Fixes https://cantina.xyz/code/8409a0ce-6c21-4cc9-8ef2-bd77ce7425af/findings/131b79f3-83fc-4674-a222-c5c4dc7d0539

But most importantly, fixes the fact that a withdrawn donation gets taxed from the vault manager

1. If the withdrawn donation corresponds to some liquidity the vault owned formerly, this liquidity gets taxed for no reason (for example: the curator bundles `updateWithdrawQueue` then `reallocate` instead of `reallocate` then `updateWithdrawQueue`)
2. The entrypoint `reallocate` now reverts as soon as at least 1 market of the withdraw queue is broken. The curator no longer can reallocate liquidity across working markets as soon as 1 market is broken: they are forced to `submitMarketRemoval` and cannot reallocate for the duration of the timelock
3. it increases the gas cost of `reallocate` in hardhat tests by 55%. This is because in hardhat tests, we most of the time reallocate liquidity between 1-3 markets while the withdraw queue contains 5 markets