### PR TITLE
Simplify comment about removed markets

### DIFF
--- a/src/interfaces/IMetaMorpho.sol
+++ b/src/interfaces/IMetaMorpho.sol
@@ -137,9 +137,8 @@ interface IMetaMorphoBase {
     /// increase the cost of depositing to the vault.
     function setSupplyQueue(Id[] calldata newSupplyQueue) external;
 
-    /// @notice Sets the withdraw queue as a permutation of the previous one, although markets with both zero cap and
-    /// zero vault's supply can be removed from the permutation.
-    /// @notice This is the only entry point to disable a market.
+    /// @notice Sets the withdraw queue as a permutation of the previous one, although some markets can be removed.
+    /// @notice This is the only entry point to remove a market.
     /// @notice Removing a market requires the vault to have 0 supply on it, or to have previously submitted a removal
     /// for this market (with the function `submitMarketRemoval`).
     /// @notice Warning: Anyone can supply on behalf of the vault so the call to `updateWithdrawQueue` that expects a

--- a/src/interfaces/IMetaMorpho.sol
+++ b/src/interfaces/IMetaMorpho.sol
@@ -137,8 +137,7 @@ interface IMetaMorphoBase {
     /// increase the cost of depositing to the vault.
     function setSupplyQueue(Id[] calldata newSupplyQueue) external;
 
-    /// @notice Sets the withdraw queue as a permutation of the previous one, although some markets can be removed.
-    /// @notice This is the only entry point to remove a market.
+    /// @notice Updates the withdraw queue. Some markets can be removed, but no market can be added.
     /// @notice Removing a market requires the vault to have 0 supply on it, or to have previously submitted a removal
     /// for this market (with the function `submitMarketRemoval`).
     /// @notice Warning: Anyone can supply on behalf of the vault so the call to `updateWithdrawQueue` that expects a


### PR DESCRIPTION
Refactor because it is already explained below the different cases where the market can be removed (also the first comment was missing a case)

fixes #362 