### PR TITLE
build: update optimizer

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,7 @@ fs_permissions = [
     { access = "read", path = "./config/"},
     { access = "read", path = "./lib/morpho-blue/out/"}
 ]
+optimizer_runs = 999999 # Etherscan does not support verifying contracts with more optimization runs.
 
 [profile.default.rpc_endpoints]
 mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}"

--- a/foundry.toml
+++ b/foundry.toml
@@ -26,4 +26,4 @@ script = "/dev/null"
 via-ir = false
 
 
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,6 @@ fs_permissions = [
     { access = "read", path = "./config/"},
     { access = "read", path = "./lib/morpho-blue/out/"}
 ]
-optimizer_runs = 999999 # Etherscan does not support verifying contracts with more optimization runs.
 
 [profile.default.rpc_endpoints]
 mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}"


### PR DESCRIPTION
Removes the optimizer runs because the factory is too heavy to be deployed with optimizations run