### PR TITLE
test(hardhat): use pyramidal deposits/withdraws

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -54,7 +54,7 @@ const config: HardhatUserConfig = {
       initialBaseFeePerGas: 0,
       allowBlocksWithSameTimestamp: true,
       accounts: {
-        count: 103, // must be odd
+        count: 53, // must be odd
       },
       mining: {
         mempool: {
@@ -68,25 +68,25 @@ const config: HardhatUserConfig = {
       {
         version: "0.8.21",
         settings: {
-          optimizer: { 
+          optimizer: {
             enabled: true,
             runs: 200,
           },
           viaIR: true,
           evmVersion: "paris",
-        }
+        },
       },
       {
         version: "0.8.19",
         settings: {
-          optimizer: { 
+          optimizer: {
             enabled: true,
             runs: 999999,
           },
           viaIR: true,
           evmVersion: "paris",
-        }
-      }
+        },
+      },
     ],
   },
   mocha: {


### PR DESCRIPTION
So the idea is that previously:
- allocation was meant to be all equal on non idle markets, but it wasn't because the idle assets were not reallocated
- withdrawing was rarely hitting more than 1 market
- users were only fresh depositing, not re-depositing

What I did is:
- fix the reallocation bug
- make so that each user interacts twice, first time they deposit a lot and withdraw not much, second time they deposit not much and withdraw a lot (with avg total deposits/withdraw equal for each user). It makes so that when interacting the second time, users are on avg withdrawing from the vault and it at least withdraws from all markets for the last user - so it's closer to prod