### PR TITLE
[Certora] Reentrancy

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         conf:
           - ConsistentState
+          - Immutability
           - Reentrancy
           - Reverts
           - Roles

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         conf:
           - ConsistentState
+          - Reentrancy
           - Reverts
           - Roles
 

--- a/certora/confs/Immutability.conf
+++ b/certora/confs/Immutability.conf
@@ -1,0 +1,16 @@
+{
+    "files": [
+        "certora/harness/MetaMorphoHarness.sol",
+    ],
+    "verify": "MetaMorphoHarness:certora/specs/Immutability.spec",
+    "loop_iter": "2",
+    "optimistic_loop": true,
+    "prover_args": [
+        "-depth 3",
+        "-mediumTimeout 20",
+        "-timeout 120",
+    ],
+    "rule_sanity": "basic",
+    "server": "production",
+    "msg": "MetaMorpho Immutability",
+}

--- a/certora/confs/Reentrancy.conf
+++ b/certora/confs/Reentrancy.conf
@@ -8,6 +8,7 @@
         "-depth 3",
         "-mediumTimeout 20",
         "-timeout 120",
+        "-enableStorageSplitting false",
     ],
     "rule_sanity": "basic",
     "server": "production",

--- a/certora/confs/Reentrancy.conf
+++ b/certora/confs/Reentrancy.conf
@@ -1,0 +1,15 @@
+{
+    "files": [
+        "certora/harness/MetaMorphoHarness.sol",
+    ],
+    "verify": "MetaMorphoHarness:certora/specs/Reentrancy.spec",
+    "optimistic_loop": true,
+    "prover_args": [
+        "-depth 3",
+        "-mediumTimeout 20",
+        "-timeout 120",
+    ],
+    "rule_sanity": "basic",
+    "server": "production",
+    "msg": "MetaMorpho Reentrancy",
+}

--- a/certora/confs/Reverts.conf
+++ b/certora/confs/Reverts.conf
@@ -21,5 +21,5 @@
     ],
     "rule_sanity": "basic",
     "server": "production",
-    "msg": "MetaMorpho Reverts"
+    "msg": "MetaMorpho Reverts",
 }

--- a/certora/specs/Immutability.spec
+++ b/certora/specs/Immutability.spec
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+methods {
+    function multicall(bytes[]) external returns(bytes[]) => NONDET DELETE;
+}
+
+persistent ghost bool delegateCall;
+
+hook DELEGATECALL(uint g, address addr, uint argsOffset, uint argsLength, uint retOffset, uint retLength) uint rc {
+    delegateCall = true;
+}
+
+// Check that the contract is truly immutable.
+rule noDelegateCalls(method f, env e, calldataarg data) {
+    // Set up the initial state.
+    require !delegateCall;
+    f(e,data);
+    assert !delegateCall;
+}

--- a/certora/specs/Reentrancy.spec
+++ b/certora/specs/Reentrancy.spec
@@ -33,7 +33,6 @@ function boolSummary() returns bool {
     return value;
 }
 
-persistent ghost bool delegateCall;
 persistent ghost bool ignoredCall;
 // True when storage has been accessed with either a SSTORE or a SLOAD.
 persistent ghost bool hasAccessedStorage;
@@ -61,10 +60,6 @@ hook CALL(uint g, address addr, uint value, uint argsOffset, uint argsLength, ui
     }
 }
 
-hook DELEGATECALL(uint g, address addr, uint argsOffset, uint argsLength, uint retOffset, uint retLength) uint rc {
-    delegateCall = true;
-}
-
 // Check that no function is accessing storage, then making an external CALL, and accessing storage again.
 rule reentrancySafe(method f, env e, calldataarg data) {
     // Set up the initial state.
@@ -72,12 +67,4 @@ rule reentrancySafe(method f, env e, calldataarg data) {
     require !hasAccessedStorage && !hasCallAfterAccessingStorage && !hasReentrancyUnsafeCall;
     f(e,data);
     assert !hasReentrancyUnsafeCall;
-}
-
-// Check that the contract is truly immutable.
-rule noDelegateCalls(method f, env e, calldataarg data) {
-    // Set up the initial state.
-    require !delegateCall;
-    f(e,data);
-    assert !delegateCall;
 }

--- a/certora/specs/Reentrancy.spec
+++ b/certora/specs/Reentrancy.spec
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+methods {
+    function multicall(bytes[]) external returns(bytes[]) => NONDET DELETE;
+}
+
+ghost bool delegateCall;
+ghost bool callToMorpho;
+// True when storage has been accessed with either a SSTORE or a SLOAD.
+ghost bool hasAccessedStorage;
+// True when a CALL has been done after storage has been accessed.
+ghost bool hasCallAfterAccessingStorage;
+// True when storage has been accessed, after which an external call is made, followed by accessing storage again.
+ghost bool hasReentrancyUnsafeCall;
+
+function summaryCallToMorpho() {
+    callToMorpho = true;
+}
+
+hook ALL_SSTORE(uint loc, uint v) {
+    hasAccessedStorage = true;
+    hasReentrancyUnsafeCall = hasCallAfterAccessingStorage;
+}
+
+hook ALL_SLOAD(uint loc) uint v {
+    hasAccessedStorage = true;
+    hasReentrancyUnsafeCall = hasCallAfterAccessingStorage;
+}
+
+hook CALL(uint g, address addr, uint value, uint argsOffset, uint argsLength, uint retOffset, uint retLength) uint rc {
+    if (callToMorpho) {
+        // Assume that calls to Morpho markets are trusted (as they have gone through a timelock).
+        callToMorpho = false;
+    } else {
+        hasCallAfterAccessingStorage = hasAccessedStorage;
+    }
+}
+
+hook DELEGATECALL(uint g, address addr, uint argsOffset, uint argsLength, uint retOffset, uint retLength) uint rc {
+    delegateCall = true;
+}
+
+// Check that no function is accessing storage, then making an external CALL, and accessing storage again.
+rule reentrancySafe(method f, env e, calldataarg data) {
+    // Set up the initial state.
+    require !callToMorpho;
+    require !hasAccessedStorage && !hasCallAfterAccessingStorage && !hasReentrancyUnsafeCall;
+    f(e,data);
+    assert !hasReentrancyUnsafeCall;
+}
+
+// Check that the contract is truly immutable.
+rule noDelegateCalls(method f, env e, calldataarg data) {
+    // Set up the initial state.
+    require !delegateCall;
+    f(e,data);
+    assert !delegateCall;
+}

--- a/certora/specs/Reentrancy.spec
+++ b/certora/specs/Reentrancy.spec
@@ -3,14 +3,14 @@ methods {
     function multicall(bytes[]) external returns(bytes[]) => NONDET DELETE;
 }
 
-ghost bool delegateCall;
-ghost bool callToMorpho;
+persistent ghost bool delegateCall;
+persistent ghost bool callToMorpho;
 // True when storage has been accessed with either a SSTORE or a SLOAD.
-ghost bool hasAccessedStorage;
+persistent ghost bool hasAccessedStorage;
 // True when a CALL has been done after storage has been accessed.
-ghost bool hasCallAfterAccessingStorage;
+persistent ghost bool hasCallAfterAccessingStorage;
 // True when storage has been accessed, after which an external call is made, followed by accessing storage again.
-ghost bool hasReentrancyUnsafeCall;
+persistent ghost bool hasReentrancyUnsafeCall;
 
 function summaryCallToMorpho() {
     callToMorpho = true;

--- a/certora/specs/Reentrancy.spec
+++ b/certora/specs/Reentrancy.spec
@@ -1,20 +1,46 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 methods {
     function multicall(bytes[]) external returns(bytes[]) => NONDET DELETE;
+
+    function _.accrueInterest(MetaMorphoHarness.MarketParams) external => voidSummary() expect void;
+    function _.supply(MetaMorphoHarness.MarketParams, uint256, uint256, address, bytes) external => uintPairSummary() expect (uint256, uint256);
+    function _.withdraw(MetaMorphoHarness.MarketParams, uint256, uint256, address, address) external => uintPairSummary() expect (uint256, uint256);
+
+    function _.transferFrom(address, address, uint256) external => boolSummary() expect bool;
+    function _.balanceOf(address) external => uintSummary() expect uint256;
+}
+
+function voidSummary() {
+    ignoredCall = true;
+}
+
+function uintSummary() returns uint256 {
+    ignoredCall = true;
+    uint256 value;
+    return value;
+}
+
+function uintPairSummary() returns (uint256, uint256) {
+    ignoredCall = true;
+    uint256 firstValue;
+    uint256 secondValue;
+    return (firstValue, secondValue);
+}
+
+function boolSummary() returns bool {
+    ignoredCall = true;
+    bool value;
+    return value;
 }
 
 persistent ghost bool delegateCall;
-persistent ghost bool callToMorpho;
+persistent ghost bool ignoredCall;
 // True when storage has been accessed with either a SSTORE or a SLOAD.
 persistent ghost bool hasAccessedStorage;
 // True when a CALL has been done after storage has been accessed.
 persistent ghost bool hasCallAfterAccessingStorage;
 // True when storage has been accessed, after which an external call is made, followed by accessing storage again.
 persistent ghost bool hasReentrancyUnsafeCall;
-
-function summaryCallToMorpho() {
-    callToMorpho = true;
-}
 
 hook ALL_SSTORE(uint loc, uint v) {
     hasAccessedStorage = true;
@@ -27,9 +53,9 @@ hook ALL_SLOAD(uint loc) uint v {
 }
 
 hook CALL(uint g, address addr, uint value, uint argsOffset, uint argsLength, uint retOffset, uint retLength) uint rc {
-    if (callToMorpho) {
-        // Assume that calls to Morpho markets are trusted (as they have gone through a timelock).
-        callToMorpho = false;
+    if (ignoredCall) {
+        // Assume that calls to Morpho markets and tokens are trusted (as they have gone through a timelock).
+        ignoredCall = false;
     } else {
         hasCallAfterAccessingStorage = hasAccessedStorage;
     }
@@ -42,7 +68,7 @@ hook DELEGATECALL(uint g, address addr, uint argsOffset, uint argsLength, uint r
 // Check that no function is accessing storage, then making an external CALL, and accessing storage again.
 rule reentrancySafe(method f, env e, calldataarg data) {
     // Set up the initial state.
-    require !callToMorpho;
+    require !ignoredCall;
     require !hasAccessedStorage && !hasCallAfterAccessingStorage && !hasReentrancyUnsafeCall;
     f(e,data);
     assert !hasReentrancyUnsafeCall;


### PR DESCRIPTION
This PR's goals is to prove that there is no possibility of a reentrancy attacks, assuming that:
- Tokens are trusted. This assumption could potentially be relaxed, based on the fact that the accounting does not depend on reentrant calls. In fact, MetaMorpho has been built with this concern in mind, notably to take into account ERC777 tokens. To simplify the verification though, tokens are assumed to not reenter the contract.
- Morpho Blue and Morpho Blue markets are trusted. Morpho Blue is an immutable contract, and thoroughly verified.

Note also that both assumption make sense in the context of timelocked markets: a market (and its corresponding collateral and loan token) can only be added after going through a timelock phase. After a proper analysis during this period, a market could be considered safe