### PR TITLE
[Certora] Forced market removal independence

### DIFF
--- a/certora/specs/ConsistentState.spec
+++ b/certora/specs/ConsistentState.spec
@@ -157,3 +157,24 @@ function hasSupplyCapIsEnabled(MetaMorphoHarness.Id id) returns bool {
 
 invariant supplyCapIsEnabled(MetaMorphoHarness.Id id)
     hasSupplyCapIsEnabled(id);
+
+function hasSupplyCapIsNotMarkedForRemoval(MetaMorphoHarness.Id id) returns bool {
+    uint192 supplyCap;
+    bool removableAt;
+    supplyCap, _, removableAt = config(id);
+
+    return supplyCap > 0 => removableAt == 0;
+}
+invariant supplyCapIsNotMarkedForRemoval(MetaMorphoHarness.Id id)
+    hasSupplyCapIsNotMarkedForRemoval(id);
+
+function hasPendingCapIsNotMarkedForRemoval(MetaMorphoHarness.Id id) returns bool {
+    uint64 pendingAt;
+    _, pendingAt = pendingCap(id);
+    bool removableAt;
+    _, _, removableAt = config(id);
+
+    return pendingAt > 0 => removableAt == 0;
+}
+invariant pendingCapIsNotMarkedForRemoval(MetaMorphoHarness.Id id)
+    hasPendingCapIsNotMarkedForRemoval(id);

--- a/certora/specs/ConsistentState.spec
+++ b/certora/specs/ConsistentState.spec
@@ -160,7 +160,7 @@ invariant supplyCapIsEnabled(MetaMorphoHarness.Id id)
 
 function hasSupplyCapIsNotMarkedForRemoval(MetaMorphoHarness.Id id) returns bool {
     uint192 supplyCap;
-    bool removableAt;
+    uint64 removableAt;
     supplyCap, _, removableAt = config(id);
 
     return supplyCap > 0 => removableAt == 0;
@@ -171,7 +171,7 @@ invariant supplyCapIsNotMarkedForRemoval(MetaMorphoHarness.Id id)
 function hasPendingCapIsNotMarkedForRemoval(MetaMorphoHarness.Id id) returns bool {
     uint64 pendingAt;
     _, pendingAt = pendingCap(id);
-    bool removableAt;
+    uint64 removableAt;
     _, _, removableAt = config(id);
 
     return pendingAt > 0 => removableAt == 0;


### PR DESCRIPTION
The goal of this PR is to prove that a market can't be marked for removal and (have supply cap > 0 or have a pending cap). This is a useful property to make sure that there are no ambiguity as what will happen to that market in the future