### PR TITLE
use deployCode in IntegrationTest so solidity version is not fixed

### DIFF
--- a/test/forge/DeploymentTest.sol
+++ b/test/forge/DeploymentTest.sol
@@ -15,9 +15,7 @@ contract DeploymentTest is IntegrationTest {
         vm.assume(address(notToken) != address(vault));
 
         vm.expectRevert();
-        createMetaMorpho(
-            OWNER, address(morpho), ConstantsLib.MIN_TIMELOCK, notToken, "MetaMorpho Vault", "MMV"
-        );
+        createMetaMorpho(OWNER, address(morpho), ConstantsLib.MIN_TIMELOCK, notToken, "MetaMorpho Vault", "MMV");
     }
 
     function testDeployMetaMorpho(
@@ -31,8 +29,7 @@ contract DeploymentTest is IntegrationTest {
         assumeNotZeroAddress(morpho);
         initialTimelock = bound(initialTimelock, ConstantsLib.MIN_TIMELOCK, ConstantsLib.MAX_TIMELOCK);
 
-        IMetaMorpho newVault =
-            createMetaMorpho(owner, morpho, initialTimelock, address(loanToken), name, symbol);
+        IMetaMorpho newVault = createMetaMorpho(owner, morpho, initialTimelock, address(loanToken), name, symbol);
 
         assertEq(newVault.owner(), owner, "owner");
         assertEq(address(newVault.MORPHO()), morpho, "morpho");

--- a/test/forge/DeploymentTest.sol
+++ b/test/forge/DeploymentTest.sol
@@ -2,12 +2,11 @@
 pragma solidity ^0.8.0;
 
 import "./helpers/IntegrationTest.sol";
-import {MetaMorpho} from "../../src/MetaMorpho.sol";
 
 contract DeploymentTest is IntegrationTest {
     function testDeployMetaMorphoAddresssZero() public {
         vm.expectRevert(ErrorsLib.ZeroAddress.selector);
-        new MetaMorpho(OWNER, address(0), ConstantsLib.MIN_TIMELOCK, address(loanToken), "MetaMorpho Vault", "MMV");
+        createMetaMorpho(OWNER, address(0), ConstantsLib.MIN_TIMELOCK, address(loanToken), "MetaMorpho Vault", "MMV");
     }
 
     function testDeployMetaMorphoNotToken(address notToken) public {
@@ -16,7 +15,9 @@ contract DeploymentTest is IntegrationTest {
         vm.assume(address(notToken) != address(vault));
 
         vm.expectRevert();
-        new MetaMorpho(OWNER, address(morpho), ConstantsLib.MIN_TIMELOCK, notToken, "MetaMorpho Vault", "MMV");
+        createMetaMorpho(
+            OWNER, address(morpho), ConstantsLib.MIN_TIMELOCK, notToken, "MetaMorpho Vault", "MMV"
+        );
     }
 
     function testDeployMetaMorpho(
@@ -30,7 +31,8 @@ contract DeploymentTest is IntegrationTest {
         assumeNotZeroAddress(morpho);
         initialTimelock = bound(initialTimelock, ConstantsLib.MIN_TIMELOCK, ConstantsLib.MAX_TIMELOCK);
 
-        MetaMorpho newVault = new MetaMorpho(owner, morpho, initialTimelock, address(loanToken), name, symbol);
+        IMetaMorpho newVault =
+            createMetaMorpho(owner, morpho, initialTimelock, address(loanToken), name, symbol);
 
         assertEq(newVault.owner(), owner, "owner");
         assertEq(address(newVault.MORPHO()), morpho, "morpho");

--- a/test/forge/DeploymentTest.sol
+++ b/test/forge/DeploymentTest.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./helpers/IntegrationTest.sol";
+import {MetaMorpho} from "../../src/MetaMorpho.sol";
 
 contract DeploymentTest is IntegrationTest {
     function testDeployMetaMorphoAddresssZero() public {

--- a/test/forge/ERC4626Test.sol
+++ b/test/forge/ERC4626Test.sol
@@ -5,7 +5,6 @@ import {IERC20Errors} from "../../lib/openzeppelin-contracts/contracts/interface
 import {IMorphoFlashLoanCallback} from "../../lib/morpho-blue/src/interfaces/IMorphoCallbacks.sol";
 
 import "./helpers/IntegrationTest.sol";
-import {MetaMorpho} from "../../src/MetaMorpho.sol";
 
 contract ERC4626Test is IntegrationTest, IMorphoFlashLoanCallback {
     using MorphoBalancesLib for IMorpho;
@@ -21,9 +20,7 @@ contract ERC4626Test is IntegrationTest, IMorphoFlashLoanCallback {
     function testDecimals(uint8 decimals) public {
         vm.mockCall(address(loanToken), abi.encodeWithSignature("decimals()"), abi.encode(decimals));
 
-        vault = IMetaMorpho(
-            address(new MetaMorpho(OWNER, address(morpho), TIMELOCK, address(loanToken), "MetaMorpho Vault", "MMV"))
-        );
+        vault = createMetaMorpho(OWNER, address(morpho), TIMELOCK, address(loanToken), "MetaMorpho Vault", "MMV");
 
         assertEq(vault.decimals(), Math.max(18, decimals), "decimals");
     }

--- a/test/forge/ERC4626Test.sol
+++ b/test/forge/ERC4626Test.sol
@@ -5,6 +5,7 @@ import {IERC20Errors} from "../../lib/openzeppelin-contracts/contracts/interface
 import {IMorphoFlashLoanCallback} from "../../lib/morpho-blue/src/interfaces/IMorphoCallbacks.sol";
 
 import "./helpers/IntegrationTest.sol";
+import {MetaMorpho} from "../../src/MetaMorpho.sol";
 
 contract ERC4626Test is IntegrationTest, IMorphoFlashLoanCallback {
     using MorphoBalancesLib for IMorpho;

--- a/test/forge/MulticallTest.sol
+++ b/test/forge/MulticallTest.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./helpers/IntegrationTest.sol";
+import {MetaMorpho} from "../../src/MetaMorpho.sol";
 
 contract MulticallTest is IntegrationTest {
     bytes[] internal data;

--- a/test/forge/MulticallTest.sol
+++ b/test/forge/MulticallTest.sol
@@ -2,15 +2,14 @@
 pragma solidity ^0.8.0;
 
 import "./helpers/IntegrationTest.sol";
-import {MetaMorpho} from "../../src/MetaMorpho.sol";
 
 contract MulticallTest is IntegrationTest {
     bytes[] internal data;
 
     function testMulticall() public {
-        data.push(abi.encodeCall(MetaMorpho.setCurator, (address(1))));
-        data.push(abi.encodeCall(MetaMorpho.setIsAllocator, (address(1), true)));
-        data.push(abi.encodeCall(MetaMorpho.submitTimelock, (ConstantsLib.MAX_TIMELOCK)));
+        data.push(abi.encodeCall(IMetaMorphoBase.setCurator, (address(1))));
+        data.push(abi.encodeCall(IMetaMorphoBase.setIsAllocator, (address(1), true)));
+        data.push(abi.encodeCall(IMetaMorphoBase.submitTimelock, (ConstantsLib.MAX_TIMELOCK)));
 
         vm.prank(OWNER);
         vault.multicall(data);

--- a/test/forge/TimelockTest.sol
+++ b/test/forge/TimelockTest.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "./helpers/IntegrationTest.sol";
-import {MetaMorpho} from "../../src/MetaMorpho.sol";
 
 uint256 constant FEE = 0.1 ether; // 10%
 
@@ -70,14 +69,14 @@ contract TimelockTest is IntegrationTest {
         timelock = bound(timelock, ConstantsLib.MAX_TIMELOCK + 1, type(uint256).max);
 
         vm.expectRevert(ErrorsLib.AboveMaxTimelock.selector);
-        new MetaMorpho(OWNER, address(morpho), timelock, address(loanToken), "MetaMorpho Vault", "MMV");
+        createMetaMorpho(OWNER, address(morpho), timelock, address(loanToken), "MetaMorpho Vault", "MMV");
     }
 
     function testDeployMetaMorphoBelowMinTimelock(uint256 timelock) public {
         timelock = bound(timelock, 0, ConstantsLib.MIN_TIMELOCK - 1);
 
         vm.expectRevert(ErrorsLib.BelowMinTimelock.selector);
-        new MetaMorpho(OWNER, address(morpho), timelock, address(loanToken), "MetaMorpho Vault", "MMV");
+        createMetaMorpho(OWNER, address(morpho), timelock, address(loanToken), "MetaMorpho Vault", "MMV");
     }
 
     function testSubmitTimelockAboveMaxTimelock(uint256 timelock) public {

--- a/test/forge/TimelockTest.sol
+++ b/test/forge/TimelockTest.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./helpers/IntegrationTest.sol";
+import {MetaMorpho} from "../../src/MetaMorpho.sol";
 
 uint256 constant FEE = 0.1 ether; // 10%
 

--- a/test/forge/helpers/BaseTest.sol
+++ b/test/forge/helpers/BaseTest.sol
@@ -22,10 +22,7 @@ import {OracleMock} from "../../../src/mocks/OracleMock.sol";
 
 import {Ownable} from "../../../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
 
-import {
-    IERC20,
-    ERC20
-} from "../../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
+import {IERC20, ERC20} from "../../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
 
 import "../../../lib/forge-std/src/Test.sol";
 import "../../../lib/forge-std/src/console2.sol";

--- a/test/forge/helpers/BaseTest.sol
+++ b/test/forge/helpers/BaseTest.sol
@@ -21,7 +21,11 @@ import {ERC20Mock} from "../../../src/mocks/ERC20Mock.sol";
 import {OracleMock} from "../../../src/mocks/OracleMock.sol";
 
 import {Ownable} from "../../../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
-import {MetaMorpho, ERC20, IERC20, MarketAllocation} from "../../../src/MetaMorpho.sol";
+
+import {
+    IERC20,
+    ERC20
+} from "../../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
 
 import "../../../lib/forge-std/src/Test.sol";
 import "../../../lib/forge-std/src/console2.sol";

--- a/test/forge/helpers/IntegrationTest.sol
+++ b/test/forge/helpers/IntegrationTest.sol
@@ -16,7 +16,7 @@ contract IntegrationTest is BaseTest {
         super.setUp();
 
         vault = IMetaMorpho(
-            deployCode("MetaMorpho.sol",abi.encode(OWNER, morpho, TIMELOCK, loanToken, "MetaMorpho Vault", "MMV"))
+            deployCode("MetaMorpho.sol", abi.encode(OWNER, morpho, TIMELOCK, loanToken, "MetaMorpho Vault", "MMV"))
         );
 
         vm.startPrank(OWNER);

--- a/test/forge/helpers/IntegrationTest.sol
+++ b/test/forge/helpers/IntegrationTest.sol
@@ -16,7 +16,7 @@ contract IntegrationTest is BaseTest {
         super.setUp();
 
         vault = IMetaMorpho(
-            address(new MetaMorpho(OWNER, address(morpho), TIMELOCK, address(loanToken), "MetaMorpho Vault", "MMV"))
+            deployCode("MetaMorpho.sol",abi.encode(OWNER, morpho, TIMELOCK, loanToken, "MetaMorpho Vault", "MMV"))
         );
 
         vm.startPrank(OWNER);

--- a/test/forge/helpers/IntegrationTest.sol
+++ b/test/forge/helpers/IntegrationTest.sol
@@ -15,9 +15,7 @@ contract IntegrationTest is BaseTest {
     function setUp() public virtual override {
         super.setUp();
 
-        vault = IMetaMorpho(
-            deployCode("MetaMorpho.sol", abi.encode(OWNER, morpho, TIMELOCK, loanToken, "MetaMorpho Vault", "MMV"))
-        );
+        vault = createMetaMorpho(OWNER, address(morpho), TIMELOCK, address(loanToken), "MetaMorpho Vault", "MMV");
 
         vm.startPrank(OWNER);
         vault.setCurator(CURATOR);
@@ -40,6 +38,21 @@ contract IntegrationTest is BaseTest {
         loanToken.approve(address(vault), type(uint256).max);
         collateralToken.approve(address(vault), type(uint256).max);
         vm.stopPrank();
+    }
+
+    // Deploy MetaMorpho from artifacts
+    // Replaces using `new MetaMorpho` which would force 0.8.21 on all tests
+    // (since MetaMorpho has pragma solidity 0.8.21)
+    function createMetaMorpho(
+        address owner,
+        address morpho,
+        uint256 initialTimelock,
+        address asset,
+        string memory name,
+        string memory symbol
+    ) public returns (IMetaMorpho) {
+        return
+            IMetaMorpho(deployCode("MetaMorpho.sol", abi.encode(owner, morpho, initialTimelock, asset, name, symbol)));
     }
 
     function _idle() internal view returns (uint256) {

--- a/test/forge/helpers/InternalTest.sol
+++ b/test/forge/helpers/InternalTest.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./BaseTest.sol";
+import {MetaMorpho} from "../../../src/MetaMorpho.sol";
 
 contract InternalTest is BaseTest, MetaMorpho {
     constructor()


### PR DESCRIPTION
MetaMorpho uses Solidity 0.8.21 (strictly). The goal is to have 0.8.24 in the [public allocator](https://github.com/morpho-org/public-allocator) but still be able to reuse Metamorpho's useful test contracts. That means not importing `MetaMorpho` in `IntegrationTest`.

This PR adds a MM-deployer function in `IntegrationTest`. It creates Metamorpho instances using `deployCode`. As with Blue, importers of MM must now have a `MetaMorphoImport.sol` file which adds `MetaMorpho` to the compilation plan.