### PR TITLE
[Certora] Added sanity checks for MarketInteractions

### DIFF
--- a/certora/confs/MarketInteractions.conf
+++ b/certora/confs/MarketInteractions.conf
@@ -14,7 +14,9 @@
         "-depth 3",
         "-mediumTimeout 20",
         "-timeout 120",
+        "-smt_nonLinearArithmetic false",
     ],
+    "rule_sanity": "basic",
     "server": "production",
     "msg": "MetaMorpho Market Interactions"
 }

--- a/certora/specs/MarketInteractions.spec
+++ b/certora/specs/MarketInteractions.spec
@@ -55,6 +55,7 @@ function summaryWithdraw(MetaMorphoHarness.MarketParams marketParams, uint256 as
 }
 
 // Check assertions in the summaries.
-// This requires to turn off sanity checks for this invariant that appears vacuous.
-invariant checkSummaries()
-    true;
+rule checkSummary(method f, env e, calldataarg args) {
+    f(e, args);
+    assert true;
+}


### PR DESCRIPTION
This enables the basic rule_sanity checks for MarketInteractions.  Instead of an invariant it uses a generic rule.