### PR TITLE
Forced removal comment

### DIFF
--- a/src/interfaces/IMetaMorpho.sol
+++ b/src/interfaces/IMetaMorpho.sol
@@ -101,8 +101,6 @@ interface IMetaMorphoBase {
     function revokePendingCap(Id id) external;
 
     /// @notice Submits a forced market removal from the vault, eventually losing all funds supplied to the market.
-    /// @notice Funds can be recovered by enabling this market again and withdrawing from it (using `reallocate`),
-    /// but funds will be distributed pro-rata to the shares at the time of withdrawal, not at the time of removal.
     /// @notice This forced removal is expected to be used as an emergency process in case a market constantly reverts.
     /// To softly remove a sane market, the curator role is expected to bundle a reallocation that empties the market
     /// first (using `reallocate`), followed by the removal of the market (using `updateWithdrawQueue`).


### PR DESCRIPTION
Forced market removal should consider funds as lost, as they are not part of the vault anymore. Additionally, they cannot be recovered easily because it would act as a donation that can be front run.